### PR TITLE
v1.1 into master

### DIFF
--- a/README_EDGE_TRIMMING.txt
+++ b/README_EDGE_TRIMMING.txt
@@ -1,0 +1,9 @@
+Edge trimming checks include:
+1.  DQ flag > 0.
+2.  Flux is > 5 * median flux (median flux calculation ignores any fluxes = 0.0).
+3.  Flux error is consistent with zero flux to within 1-sigma.
+4.  Flux value is exactly 0.0 (STIS) or < 0.0 (COS).
+
+Two different sets of start/end indexes are returned.  The first includes the DQ test, the second does not.  Some spectra have all fluxes with DQ > 0, in which case it falls back to the test that does not check DQ flags to determine the start/end indexes of the spectrum.
+
+DQ flag > 0 is way too liberal of a cut, need to be more selective on what DQ flags I remove, at least for STIS.

--- a/make_hst_spec_previews.py
+++ b/make_hst_spec_previews.py
@@ -1,4 +1,4 @@
-__version__ = '1.05'
+__version__ = '1.1'
 
 """
 .. module:: make_hst_spec_previews
@@ -29,19 +29,6 @@ class HSTSpecPrevError(Exception):
         Overrides the str function for this class.
         """
         return "*** MAKE_HST_SPEC_PREVIEWS ERROR: "+repr(self.value)
-
-
-def setup_args():
-    """
-    Set up command-line arguments and options.
-    :returns: ArgumentParser -- Stores arguments and options.
-    """
-    parser = argparse.ArgumentParser(description="Create spectroscopic preview plots given an HST spectrum FITS file.")
-    parser.add_argument("-f", action="store", type=str, dest="input_file", default=None, help="[Required] Full path to input file (HST spectrum) for which to generate preview plots.  Include the file name in the path.",metavar='input file')
-    parser.add_argument("-o", action="store", type=str, dest="output_path", default="", help="[Optional] Full path to output plot files.  Do not inclue file name in path.  Default is the same directory as the input file.",metavar='output path')
-    parser.add_argument("-t", action="store", type=str, dest="output_type", default="png", help='[Optional] Specify where plots should be output.  Default = "png".', choices=['png','PNG','eps', 'EPS', 'screen','SCREEN'], metavar='{png,ps,screen}')
-    parser.add_argument("-v", action="store_true", dest="verbose", default=False, help='[Optional] Turn on verbose messages/logging.  Default = "False".')
-    return parser
 
 
 def check_input_options(args):
@@ -123,20 +110,37 @@ def make_hst_spec_previews(args):
         """Get wavelengths, fluxes, flux uncertainties."""
         cos_spectrum = specutils_cos.readspec(args.input_file)
         """Make plots."""
-        specutils_cos.plotspec(cos_spectrum, args.output_type, output_file, output_size=1024)
-        specutils_cos.plotspec(cos_spectrum, args.output_type, output_file, output_size=128)
+        specutils_cos.plotspec(cos_spectrum, args.output_type, output_file, output_size=1024, debug=args.debug, full_ylabels=args.full_ylabels)
+        if not args.debug:
+            specutils_cos.plotspec(cos_spectrum, args.output_type, output_file, output_size=128)
     elif this_instrument == 'STIS':
         """Get wavelengths, fluxes, flux uncertainties."""
         stis_spectrum = specutils_stis.readspec(args.input_file)
         """Make plots."""
-        specutils_stis.plotspec(stis_spectrum, args.output_type, output_file, output_size=1024)
-        specutils_stis.plotspec(stis_spectrum, args.output_type, output_file, output_size=128)
+        specutils_stis.plotspec(stis_spectrum, args.output_type, output_file, output_size=1024, debug=args.debug, full_ylabels=args.full_ylabels)
+        if not args.debug:
+            specutils_stis.plotspec(stis_spectrum, args.output_type, output_file, output_size=128)
     else:
         try:
             raise HSTSpecPrevError('"INSTRUME" keyword not understood: ' + this_instrument)
         except HSTSpecPrevError as error_string:
             print error_string
             exit(1)
+
+def setup_args():
+    """
+    Set up command-line arguments and options.
+    :returns: ArgumentParser -- Stores arguments and options.
+    """
+    parser = argparse.ArgumentParser(description="Create spectroscopic preview plots given an HST spectrum FITS file.")
+    parser.add_argument("-f", action="store", type=str, dest="input_file", default=None, help="[Required] Full path to input file (HST spectrum) for which to generate preview plots.  Include the file name in the path.",metavar='input file')
+    parser.add_argument("-o", action="store", type=str, dest="output_path", default="", help="[Optional] Full path to output plot files.  Do not inclue file name in path.  Default is the same directory as the input file.",metavar='output path')
+    parser.add_argument("-t", action="store", type=str, dest="output_type", default="png", help='[Optional] Specify where plots should be output.  Default = "png".', choices=['png','PNG','eps', 'EPS', 'screen','SCREEN'], metavar='{png,ps,screen}')
+    parser.add_argument("-v", action="store_true", dest="verbose", default=False, help='[Optional] Turn on verbose messages/logging.  Default = "False".')
+    parser.add_argument("-d", action="store_true", dest="debug", default=False, help='[Optional] Turn on debug mode, which will plot to the screen and color-code fluxes based on different rejection criteria.')
+    parser.add_argument("-y", action="store_true", dest="full_ylabels", default=False, help='[Optional] Label y-axis with full values, including powers of ten in scientific notation.  Default=False.')
+    return parser
+
 
 if __name__ == "__main__":
     """Create ArgumentParser object that holds arguments and options."""

--- a/make_html.py
+++ b/make_html.py
@@ -1,0 +1,94 @@
+__version__ = '1.0'
+
+"""
+.. module:: make_html
+   :synopsis: Creates a webpage of thumbnail and full-size previews for review purposes.
+.. moduleauthor:: Scott W. Fleming <fleming@stsci.edu>
+"""
+
+from glob import glob
+import os
+import argparse
+import numpy
+
+def make_html(idir=None, ofile="plot_previews.html"):
+    if idir is not None:
+        """Get all of the thumb and full-size .png files at this location."""
+        if os.path.isdir(idir):
+            all_thumb_png_files = numpy.asarray(glob(idir+'/*0128.png'))
+            all_large_png_files = numpy.asarray(glob(idir+'/*1024.png'))
+            n_thumb_png_files = len(all_thumb_png_files); n_large_png_files = len(all_large_png_files)
+            if n_thumb_png_files > 0:
+                all_thumb_png_files_froots = ['_'.join(os.path.basename(x).split('_')[0:2]) for x in all_thumb_png_files]
+                thumb_sort_indexes = numpy.argsort(all_thumb_png_files_froots)
+                all_thumb_png_files = all_thumb_png_files[thumb_sort_indexes]
+            if n_large_png_files > 0:
+                all_large_png_files_froots = ['_'.join(os.path.basename(x).split('_')[0:2]) for x in all_large_png_files]
+                large_sort_indexes = numpy.argsort(all_large_png_files_froots)
+                all_large_png_files = all_large_png_files[large_sort_indexes]
+        else:
+            raise IOError("Could not find directory " + idir)
+        """Get a list of unique <IPPPSSOOT_filetype> base names from both the all_thumb and all_large arrays.  This is because, in principle, there might only be a preview thumbnail or a full-size preview for a given IPPPSSOOT_filetype."""
+        all_fileroots = numpy.concatenate([all_thumb_png_files, all_large_png_files])
+        for i,froot in enumerate(all_fileroots):
+            all_fileroots[i] = '_'.join(os.path.basename(froot).split('_')[0:2])
+        """Note that this array should be sorted since the "unique" function returns a sorted array."""
+        uniq_fileroots = numpy.unique(all_fileroots)
+        """Open HTML for writing and begin printing HTML table, where each row is one of the unique fileroots."""
+        cur_thumb_index = 0; cur_large_index = 0
+        with open(ofile, 'w') as of:
+            of.write('<html><head></head><body>\n')
+            of.write('<table style="border:1px solid black;border-collapse:collapse;width:1160px">\n')
+            for ufr in uniq_fileroots:
+                if n_thumb_png_files > 0:
+                    if '_'.join(os.path.basename(all_thumb_png_files[cur_thumb_index]).split('_')[0:2]) == ufr:
+                        has_thumb = True
+                    else:
+                        has_thumb = False
+                else:
+                    has_thumb = False
+                if n_large_png_files > 0:
+                    if '_'.join(os.path.basename(all_large_png_files[cur_large_index]).split('_')[0:2]) == ufr:
+                        has_large = True
+                    else:
+                        has_large = False
+                else:
+                    has_large = False
+
+                if has_thumb or has_large:
+                    of.write('  <tr>\n')
+                    """Write the cell containing the thumbnail preview, (or just fill it grey if missing)."""
+                    of.write('    <td style="border:1px solid black;width:135px;vertical-align:top"><div style="width:128px;text-align:center"><span style="font-weight:bold">'+ufr+'</span></div>')
+                    if has_thumb:
+                        of.write('<img src="'+all_thumb_png_files[cur_thumb_index]+'" width="128px">')
+                    else:
+                        of.write('<div style="background-color:#86867D;width:128px;height:128px"></div>')
+                    of.write('</td>\n')
+
+                    """Write the cell containing the large preview, (or just fill it grey if missing)."""
+                    of.write('    <td style="border:1px solid black;width:1030px">')
+                    if has_large:
+                        of.write('<img src="'+all_large_png_files[cur_large_index]+'" width="1024px">')
+                    else:
+                        of.write('<div style="background-color:#86867D;width:1024px;height:1024px"></div>')
+                    of.write('</td>\n')
+
+                    of.write('  </tr>\n')
+                else:
+                    print "Warning: Could not find either thumbnail or full-size PNG for IPPPSSOOT_filetype = " + ufr
+                    import ipdb; ipdb.set_trace()
+                if has_thumb:
+                    cur_thumb_index+=1
+                if has_large:
+                    cur_large_index+=1
+            of.write('</table>\n')
+            of.write('</body></html>\n')
+    else:
+        raise ValueError("No preview plot directory specified.")
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Create HTML page of preview plots, given an output directory.")
+    parser.add_argument("-d", action="store", type=str, dest="input_dir", default=None, help="[Required] Full path to directory containing preview plots.",metavar='location of plots')
+    parser.add_argument("-o", action="store", type=str, dest="output_file", default="plot_previews.html", help='[Optional] Full path and file name of the output HTML file.  If the file already exists, it will be overwritten.  Defualt = "plot_previews.html".')
+    args = parser.parse_args()
+    make_html(args.input_dir, args.output_file)

--- a/specutils.py
+++ b/specutils.py
@@ -1,0 +1,372 @@
+__version__ = '1.1'
+
+"""
+.. module:: specutils
+   :synopsis: Contains utility functions for reading and plotting HST spectra.
+.. moduleauthor:: Scott W. Fleming <fleming@stsci.edu>
+"""
+
+import math
+import numpy
+import specutils_cos
+import specutils_stis
+
+class AvoidRegion:
+    """
+    Defines an avoid region, which is simply a section of wavelength space that should not be included when determining the optimal y-axis plot range.  The object consists of a starting wavelength, ending wavelength, and string description of what that region is.
+    :raises: ValueError
+    """
+    def __init__(self, minwl=None, maxwl=None, description=""):
+        if minwl is None:
+            raise ValueError("Must specify a minimum wavelength for this avoid region.")
+        if maxwl is None:
+            raise ValueError("Must specify a maximum wavelength for this avoid region.")
+        if minwl >= maxwl:
+            raise ValueError("Minimum wavelength must be less than maximum wavelength for this avoid region.  Given min. wavelength = "+str(minwl)+" and max. wavelength = "+str(maxwl)+".")
+        self.minwl = minwl
+        self.maxwl = maxwl
+        self.description = description
+
+def debug_oplot(this_plotarea, all_wls, all_fls, all_flerrs, all_dqs, median_flux, median_fluxerr, flux_scale_factor, fluxerr_scale_factor, fluxerr_95th):
+    this_plotarea.errorbar(all_wls, all_fls, yerr=all_flerrs, ecolor='c', color='k', label='Passed')
+    if numpy.isfinite(median_flux):
+        where_fluxtoolarge = numpy.where( abs(all_fls/median_flux) > flux_scale_factor )
+        if len(where_fluxtoolarge[0]) > 0:
+            this_plotarea.plot(all_wls[where_fluxtoolarge], all_fls[where_fluxtoolarge], 'bo', label="Flux>>Median")
+
+    where_allzero = numpy.where(all_fls == 0.0)
+    if len(where_allzero[0]) > 0:
+        this_plotarea.plot(all_wls[where_allzero], all_fls[where_allzero], 'go', label="Flux=0")
+
+    where_dqnotzero = numpy.where((all_dqs > 0) & (all_dqs != 16))
+    if len(where_dqnotzero[0]) > 0:
+        this_plotarea.plot(all_wls[where_dqnotzero], all_fls[where_dqnotzero], 'ro', label="DQ>0")
+
+    if numpy.isfinite(median_fluxerr):
+        where_bigerr = numpy.where(all_flerrs/median_fluxerr > fluxerr_scale_factor)
+        if len(where_bigerr[0]) > 0:
+            this_plotarea.plot(all_wls[where_bigerr], all_fls[where_bigerr], 'mo', label="FluxErr>>Median")
+
+    where_bigerrpercentile = numpy.where(all_flerrs > fluxerr_95th)
+    if len(where_bigerrpercentile[0]) > 0:
+        this_plotarea.plot(all_wls[where_bigerrpercentile], all_fls[where_bigerrpercentile], 'yo', label="FluxErr>95th %")
+
+    this_plotarea.legend(loc="upper center", ncol=4)
+
+def dq_has_flag(dq, flag_to_check):
+    """
+    Returns true/false if the given DQ flag value has the given flag value set after unpacked into a 16-bit string.  For example, dq_has_flag(48,16) would return True, but dq_has_flag(40, 16) would return False.
+    :param dq: The DQ flag to test.
+    :type dq: int
+    :param flag_to_check: The flag value that we want to check is set to True.
+    :type flag_to_check: int
+    :returns: bool -- Returns True if `flag_to_check` is set to True inside `dq`.
+    """
+    """Make sure flag_to_check is a power of 2."""
+    if (flag_to_check & (flag_to_check-1)) == 0 and flag_to_check != 0:
+        dq_16bit_str = "{0:b}".format(dq)
+        flag_16bit_str = "{0:b}".format(flag_to_check)
+        if len(flag_16bit_str) <= len(dq_16bit_str):
+            if dq_16bit_str[-1*len(flag_16bit_str)] == '1':
+                return True
+            else:
+                return False
+        else:
+            return False
+    else:
+        raise ValueError("Flag to check must be a power of 2.  Asked to check whether flag " + str(flag_to_check) + " is set to True in bitmask value " + str(dq) + ", but " + str(flag_to_check) + " is not a power of 2.")
+
+def edge_trim(instrument, fluxes, fluxerrs, dqs, n_consecutive, median_flux, flux_scale_factor, median_fluxerr, fluxerr_scale_factor, fluxerr_95th):
+    """
+    Returns start and end indexes (end are negative indexed) of the best part of the spectrum following some prescription.  Returns the start and end indexes without taking into account DQ flags AND taking into account DQ flags (since some spectra have all DQ flags set > 0).
+    :param instrument: The instrument that is being tested.
+    :type instrument: str
+    :param fluxes: The fluxes to be plotted.
+    :type fluxes: numpy.ndarray
+    :param fluxerrs: The uncertainties of the fluxes to be plotted.
+    :type fluxerrs: numpy.ndarray
+    :param dqs: The DQ flags of the spectrum.
+    :type dqs: numpy.ndarray
+    :param n_consecutive: The consecutive number of fluxes that must belong to the "best" part of the spectrum for the start/end index to count.
+    :type n_consecutive: int
+    :param median_flux: The median flux, used in determining where the best part of the spectrum is.
+    :type median_flux: float
+    :param flux_scale_factor: Max. allowed ratio between the flux and a median flux value, used in edge trimming.  Default = 10.
+    :type flux_scale_factor: float
+    :param median_fluxerr: The median flux uncertainty, used in determining where the best part of the spectrum is.
+    :type median_fluxerr: float
+    :param fluxerr_scale_factor: Max. allowed ratio between the flux uncertainty and a median flux uncertainty value, used in edge trimming.  Default = 5.
+    :type fluxerr_scale_factor: float
+    :param fluxerr_95th: The flux uncertainty corresponding to the 95th percentile.
+    :type fluxerr_95th: float
+    :returns: int tuple -- Indexes that define the best part of the spectrum, in the order of (start_index_nodq, end_index_nodq, start_index_withdq, end_index_withdq).
+    """
+    n_fluxes = len(fluxes)
+    start_index = 0 ; start_index_nodq = 0 ; start_index_withdq = 0
+    end_index = -1 ; end_index_nodq = -1 ; end_index_withdq = -1
+
+    done_trimming = False
+    done_trimming_withdq = False
+    while not done_trimming and not done_trimming_withdq:
+        if start_index > n_fluxes-n_consecutive-1:
+            done_trimming = True
+            done_trimming_withdq = True
+        else:
+            if not numpy.any(_set_plot_xrange_test(instrument,fluxes[start_index:start_index+n_consecutive+1], fluxerrs[start_index:start_index+n_consecutive+1], median_flux, flux_scale_factor, median_fluxerr, fluxerr_scale_factor, fluxerr_95th, dqs[start_index:start_index+n_consecutive+1], checkFluxes=True, checkFluxRatios=False, checkFluxErrRatios=True, checkFluxErrPercentile=False, checkDQs=False)):
+                """Test if next "n_consecutive" points also *fail* the edge effect test, e.g., they are from the *good* part of the spectrum, and if so, then we have found a good location."""
+                start_index_nodq = start_index
+                done_trimming = True
+            if not numpy.any(_set_plot_xrange_test(instrument,fluxes[start_index:start_index+n_consecutive+1], fluxerrs[start_index:start_index+n_consecutive+1], median_flux, flux_scale_factor, median_fluxerr, fluxerr_scale_factor, fluxerr_95th, dqs[start_index:start_index+n_consecutive+1], checkFluxes=True, checkFluxRatios=False, checkFluxErrRatios=True, checkFluxErrPercentile=False, checkDQs=True)):
+                """Test if next "n_consecutive" points also *fail* the edge effect test taking into account DQ flags, e.g., they are from the *good* part of the spectrum, and if so, then we have found a good location."""
+                start_index_withdq = start_index
+                done_trimming_withdq = True
+            start_index += 1
+    
+    """Now determine end indexes."""
+    done_trimming = False
+    done_trimming_withdq = False
+
+    while not done_trimming or not done_trimming_withdq:
+        if end_index < -1*(n_fluxes-n_consecutive):
+            done_trimming = True
+            done_trimming_withdq = True
+        else:
+            if end_index != -1 and not numpy.any(_set_plot_xrange_test(instrument,fluxes[end_index-n_consecutive:end_index+1], fluxerrs[end_index-n_consecutive:end_index+1], median_flux, flux_scale_factor, median_fluxerr, fluxerr_scale_factor, fluxerr_95th, dqs[end_index-n_consecutive:end_index+1], checkFluxes=True, checkFluxRatios=False, checkFluxErrRatios=True, checkFluxErrPercentile=False, checkDQs=False)):
+                """Test if next "n_consecutive" points also *fail* the edge effect test, e.g., they are from the *good* part of the spectrum, and if so, then we have found a good location and can break out of the while loop."""
+                done_trimming = True
+                end_index_nodq = end_index
+            if end_index == -1 and not numpy.any(_set_plot_xrange_test(instrument,fluxes[end_index-n_consecutive:], fluxerrs[end_index-n_consecutive:], median_flux, flux_scale_factor, median_fluxerr, fluxerr_scale_factor, fluxerr_95th, dqs[end_index-n_consecutive:end_index+1], checkFluxes=True, checkFluxRatios=False, checkFluxErrRatios=True, checkFluxErrPercentile=False, checkDQs=False)):
+                """Also test if next "n_consecutive" points also *fail* the edge effect test, e.g., they are from the *good* part of the spectrum, and if so, then we have found a good location and can break out of the while loop.  This extra test is needed due to the vagaries of how python slicing syntax works with negaive indexes.  Probably could just re-write this entirely to use non-negative indexes, but the logic works either way."""
+                done_trimming = True
+                end_index_nodq = end_index
+            if end_index != -1 and not numpy.any(_set_plot_xrange_test(instrument,fluxes[end_index-n_consecutive:end_index+1], fluxerrs[end_index-n_consecutive:end_index+1], median_flux, flux_scale_factor, median_fluxerr, fluxerr_scale_factor, fluxerr_95th, dqs[end_index-n_consecutive:end_index+1], checkFluxes=True, checkFluxRatios=False, checkFluxErrRatios=True, checkFluxErrPercentile=False, checkDQs=True)):
+                """Test if next "n_consecutive" points also *fail* the edge effect test, e.g., they are from the *good* part of the spectrum, and if so, then we have found a good location and can break out of the while loop."""
+                done_trimming_withdq = True
+                end_index_withdq = end_index
+            if end_index == -1 and not numpy.any(_set_plot_xrange_test(instrument,fluxes[end_index-n_consecutive:], fluxerrs[end_index-n_consecutive:], median_flux, flux_scale_factor, median_fluxerr, fluxerr_scale_factor, fluxerr_95th, dqs[end_index-n_consecutive:], checkFluxes=True, checkFluxRatios=False, checkFluxErrRatios=True, checkFluxErrPercentile=False, checkDQs=True)):
+                """Also test if next "n_consecutive" points also *fail* the edge effect test, e.g., they are from the *good* part of the spectrum, and if so, then we have found a good location and can break out of the while loop.  This extra test is needed due to the vagaries of how python slicing syntax works with negaive indexes.  Probably could just re-write this entirely to use non-negative indexes, but the logic works either way."""
+                done_trimming_withdq = True
+                end_index_withdq = end_index
+            end_index -= 1
+    return start_index_nodq, end_index_nodq, start_index_withdq, end_index_withdq
+
+def rms(values, offset=0.):
+    """
+    Calculates the RMS about some offset (default offset is 0.)
+    :param values: Array of values to compute the rms of.
+    :type values: numpy.ndarray
+    :param offset: Optional offset to compute the rms about.  Defaults to 0.0.
+    :type offset: float
+    :returns: float -- A scalar float containing the rms about the offset.
+    """
+    return math.sqrt(numpy.nanmean([(x-offset)**2 for x in values]))
+
+def _set_plot_xrange_test(instrument, flux_values, flux_err_values, median_flux, flux_scale_factor, median_fluxerr, fluxerr_scale_factor, fluxerr_95th, dqs, checkFluxes=False, checkFluxRatios=False, checkFluxErrRatios=False, checkFluxErrPercentile=False, checkDQs=False):
+    """
+    Defines the test for an invalid part of the spectrum when trimming from the edges along the wavelength (x) axis.
+    :param instrument: The instrument that is being tested.
+    :type instrument: str
+    :param flux_values: An array of fluxes to test.
+    :type flux_values: numpy.ndarray
+    :param flux_err_values: An array of associated flux uncertainties.
+    :type flux_err_values: numpy.ndarray
+    :param median_flux: A median flux value, used in the test.
+    :type median_flux: float
+    :param flux_scale_factor: Max. allowed ratio between the flux and a median flux value, used in edge trimming.  Default = 10.
+    :type flux_scale_factor: float
+    :param median_fluxerr: A median flux uncertainty value, used in the test.
+    :type median_fluxerr: float
+    :param fluxerr_scale_factor: Max. allowed ratio between the flux uncertainty and a median flux uncertainty value, used in edge trimming.  Default = 5.
+    :type fluxerr_scale_factor: float
+    :param fluxerr_95th: The flux uncertainty corresponding to the 95th percentile.
+    :type fluxerr_95th: float
+    :param dqs: The array of DQ flags to use in the test.
+    :type dqs: numpy.ndarray
+    :param checkFluxes: Should the value of the fluxes be used to test edge trimming?
+    :type checkFluxes: bool
+    :param checkFluxRatios: Should the ratio of the fluxes to the median flux value be used to test edge trimming?
+    :type checkFluxRatios: bool
+    :param checkFluxErrRatios: Should the ratio of the flux uncertainties to the median flux uncertainty be used to test edge trimming?
+    :type checkFluxErrRatios: bool
+    :param checkFluxErrPercentile: Should the highest percentile flux uncertainties be used to test edge trimming?
+    :type checkFluxErrPercentile: bool
+    :param checkDQs: Should the highest percentile flux uncertainties be used to test edge trimming?
+    :type checkDQs: bool
+    :returns: list -- A list of True/False values depening on whether the input flux values pass the test.  Note that if a return value is True, then the flux value is considered PART OF THE SPECTRUM TO TRIM/SKIP OVER.  If median_flux is input as NaN, then this function returns True for all flux_values (i.e., skip all of them since median_flux is not defined).
+    """
+    if not isinstance(flux_values, numpy.ndarray) or not isinstance(flux_err_values, numpy.ndarray) or not isinstance(dqs, numpy.ndarray):
+        raise ValueError("The flux, flux uncertainty, and DQ values must be passed as a numpy.ndarray object.")
+    if numpy.isfinite(median_flux):
+        return_var = [((instrument == "cos" and x <= 0. and checkFluxes) or (instrument == "stis" and x == 0. and checkFluxes)) or (abs(x/median_flux) >= flux_scale_factor and checkFluxRatios) or (y/median_fluxerr >= fluxerr_scale_factor and checkFluxErrRatios) or (y > fluxerr_95th and checkFluxErrPercentile) or ((instrument == "stis" and z > 0 and z != 16 and checkDQs) or (instrument == "cos" and z > 0 and checkDQs)) for x,y,z in zip(flux_values, flux_err_values, dqs)]
+    else:
+        return_var = [True] * len(flux_values)
+    return return_var
+    
+def set_plot_xrange(instrument,wavelengths,fluxes,fluxerrs,dqs,n_consecutive=20,flux_scale_factor=10.,fluxerr_scale_factor=5.):
+    """
+    Given an array of wavelengths and fluxes, returns a list of [xmin,xmax] to define an optimal x-axis plot range.
+    :param wavelengths: The wavelengths to be plotted.
+    :param instrument: The instrument that is being tested.
+    :type instrument: str
+    :type wavelengths: numpy.ndarray
+    :param fluxes: The fluxes to be plotted.
+    :type fluxes: numpy.ndarray
+    :param fluxerrs: The uncertainties of the fluxes to be plotted.
+    :type fluxerrs: numpy.ndarray
+    :param dqs: The DQ flags of the spectrum to be plotted.
+    :type dqs: numpy.ndarray
+    :param n_consecutive: How many consecutive points must pass the test for the index to count as the valid start/end of the spectrum?  Default = 20.
+    :type n_consecutive: int
+    :param flux_scale_factor: Max. allowed ratio between the flux and a median flux value, used in edge trimming.  Default = 10.
+    :type flux_scale_factor: float
+    :param fluxerr_scale_factor: Max. allowed ratio between the flux uncertainty and a median flux uncertainty value, used in edge trimming.  Default = 5.
+    :type fluxerr_scale_factor: float
+    :returns: list -- Two-element list containing the optimal [xmin,xmax] values to define the x-axis plot range.
+    """
+    """Test if there are any NaN's in the wavelength array.  If so, issue a warning for now..."""
+    """ NOTE: Use of the SUM here was reported on stackoverflow to be faster than MIN...it won't matter for the sizes we're dealing with here, but I thought it was a neat trick."""
+    if numpy.isnan(numpy.sum(wavelengths)):
+        print "***WARNING in SPECUTILS_STIS: Wavelength array contains NaN values.  Behavior has not been fully tested in this case."
+    """Find the median flux value, ignoring any NaN values or fluxes that are 0.0."""
+    where_finite_and_notzero = numpy.where( (numpy.isfinite(fluxes)) & (fluxes != 0.0) )
+    if len(where_finite_and_notzero[0]) > 0:
+        median_flux = numpy.median(fluxes[where_finite_and_notzero])
+        median_fluxerr = numpy.median(fluxerrs[where_finite_and_notzero])
+    else:
+        median_flux = numpy.nan
+        median_fluxerr = numpy.nan
+    """Get the largest flux uncertainties."""
+    fluxerr_95th = numpy.percentile(fluxerrs, 95.)
+    """Find the first element in the array that is NOT considered an "edge effect", and the last element in the array that is NOT considered an "edge effect".  If the input array is all zeroes, then it will find the last and first element, respectively.  Note that the trim does not just stop at the first index that satisfies this requirement, since there can be spikes at the edges that can fool the algorithm.  Instead, it requires that the next "n_consecutive" data points after each trial location also fail the test for "edge effect"."""
+    start_index_nodq, end_index_nodq, start_index_withdq, end_index_withdq = edge_trim(instrument, fluxes, fluxerrs, dqs, n_consecutive, median_flux, flux_scale_factor, median_fluxerr, fluxerr_scale_factor, fluxerr_95th)
+    """Return the optimal start and end wavelength values for defining the x-axis plot range.  Note that if the fluxes are all zeroes, then start index will be past end index, so we return NaN values to indicate a special plot should be made in that case.  The odd conditional below checks to make sure the end index (working from the back of the list via negative indexes) stops before reaching the start index (which works from the front using zero-based, positive indexes), otherwise return NaN values because the array is all zeroes."""
+    if len(fluxes) + end_index_withdq > start_index_withdq:
+        return median_flux, flux_scale_factor, median_fluxerr, fluxerr_scale_factor, fluxerr_95th, [wavelengths[start_index_withdq],wavelengths[end_index_withdq]]
+    elif len(fluxes) + end_index_nodq > start_index_nodq:
+        return median_flux, flux_scale_factor, median_fluxerr, fluxerr_scale_factor, fluxerr_95th, [wavelengths[start_index_nodq],wavelengths[end_index_nodq]]
+    else:
+        return median_flux, flux_scale_factor, median_fluxerr, fluxerr_scale_factor, fluxerr_95th, [numpy.nan,numpy.nan]
+
+def set_plot_yrange(wavelengths,fluxes,avoid_regions=None,wl_range=None):
+    """
+    Given an array of wavelengths, fluxes, and avoid regions, returns a list of [ymin,ymax] to define an optimal y-axis plot range.
+    :param wavelengths: The wavelengths to be plotted.
+    :type wavelengths: numpy.ndarray
+    :param fluxes: The fluxes to be plotted.
+    :type fluxes: numpy.ndarray
+    :param avoid_regions: A list of wavelength ranges to avoid when calculating optimal y-axis plot range.
+    :type avoid_regions: list of STISAvoidRegion objects.
+    :param wl_range: The min. and max. wavelength that defines the x-axis plot range.  The default is None, in which case the min. and max. if the input wavelength array will be used.
+    :type wl_range: list
+    :returns: list -- Two-element list containing the optimal [ymin,ymax] values to define the y-axis plot range.
+    .. note::
+       This function makes use of an internal look-up table of wavelength regions where known contaminating emission lines or other strong UV artifacts can affect the zoom level of the plot.
+    """
+    if wl_range is None:
+        wl_range = [numpy.nanmin(wavelengths), numpy.nanmax(wavelengths)]
+    """This list will keep track of which fluxes to retain when defining the y-axis plot range, where setting the value to 1 means keep this flux for consideration."""
+    keep_indices = [1] * len(wavelengths)
+    if avoid_regions is not None:
+        for i,ar in enumerate(avoid_regions):
+            if i == 0:
+                reject_indices = [i for i in range(len(wavelengths)) if wavelengths[i] >= ar.minwl and wavelengths[i] <= ar.maxwl or wavelengths[i] < wl_range[0] or wavelengths[i] > wl_range[1]]
+            else:
+                """Don't need to worry about checking wavelengths within bounds after the first avoid region is examined."""
+                reject_indices = [i for i in range(len(wavelengths)) if wavelengths[i] >= ar.minwl and wavelengths[i] <= ar.maxwl]
+            for j in reject_indices:
+                keep_indices[j] = 0
+    keep_fluxes = numpy.asarray([f for ii,f in enumerate(fluxes) if keep_indices[ii] == 1 and numpy.isfinite(fluxes[ii])])
+    """Don't just take the pure min and max, since weird defects can affect the calculation.  Instead, take the 1th and 99th percentile fluxes within the region to consider."""
+    min_flux = numpy.percentile(keep_fluxes,1.)
+    max_flux = numpy.percentile(keep_fluxes,99.)
+    """Determine a y-buffer based on the difference between the max. and min. flux."""
+    ybuffer = 0.1 * (max_flux-min_flux)
+    if min_flux != max_flux:
+        return [min_flux-ybuffer, max_flux+ybuffer]
+    else:
+        return [min_flux-1., max_flux+1.]
+
+def stitch_components(input_exposure, segment_names=None):
+    """
+    Given a COSSpectrum or STISExposureSpectrum object, stitches each segment/order, respectively, into a contiguous array.
+    :param input_exposure: The COS segment or STIS exposure spectrum to stitch.
+    :type input_exposure: COSSpectrum or STISExposureSpectrum
+    :param segment_names: List of segment names if input_exposure is a COSSpectrum object.
+    :type segment_names: list
+    :returns: numpy array, numpy array, numpy array, str -- The stitched wavelengths, fluxes, flux errors, and an informational plot title in the event that all the fluxes had the DQ flag set.
+    """
+    all_wls = [] ; all_fls = [] ; all_flerrs = [] ; all_dqs = []
+    if isinstance(input_exposure, specutils_cos.COSSpectrum):
+        if segment_names is not None:
+            n_components = len(segment_names)
+            loop_iterable = segment_names
+            inst_type = "cos"
+        else:
+            raise ValueError("Must provide a list of segment names for COS spectra.")
+    elif isinstance(input_exposure, specutils_stis.STISExposureSpectrum):
+        n_components = len(input_exposure.orders)
+        loop_iterable = xrange(n_components)
+        inst_type = "stis"
+    else:
+        raise ValueError("Input must be either a COSSpectrum or STISExposureSpectrum object.")
+    
+    all_dq_flags = numpy.zeros(n_components)
+    return_title = ""
+
+    for jj,j in enumerate(loop_iterable):
+        if inst_type == "stis":
+            these_wls = input_exposure.orders[j].wavelengths
+            these_fls = input_exposure.orders[j].fluxes
+            these_flerrs = input_exposure.orders[j].fluxerrs
+            these_dqs = input_exposure.orders[j].dqs
+        elif inst_type == "cos":
+            these_wls = input_exposure.segments[j].wavelengths
+            these_fls = input_exposure.segments[j].fluxes
+            these_flerrs = input_exposure.segments[j].fluxerrs
+            these_dqs = input_exposure.segments[j].dqs
+            
+        """Trim from the edges anything with a DQ flag > 0 and != 16."""
+        start_index = 0
+        while start_index < len(these_dqs):
+            if these_dqs[start_index] == 0 or these_dqs[start_index] == 16:
+                break
+            else:
+                start_index += 1
+        end_index = -1
+        while end_index >= -1*len(these_dqs):
+            if these_dqs[end_index] == 0 or these_dqs[end_index] == 16:
+                break
+            else:
+                end_index -= 1
+        """Only append the parts of this order's spectrum that are not DQ > 0 and != 16 at the edges."""
+        if len(these_dqs) + end_index > start_index:
+            if end_index == -1:
+                all_wls += list(these_wls[start_index:])
+                all_fls += list(these_fls[start_index:])
+                all_flerrs += list(these_flerrs[start_index:])
+                all_dqs += list(these_dqs[start_index:])
+            else:
+                all_wls += list(these_wls[start_index:end_index+1])
+                all_fls += list(these_fls[start_index:end_index+1])
+                all_flerrs += list(these_flerrs[start_index:end_index+1])
+                all_dqs += list(these_dqs[start_index:end_index+1])
+        else:
+            all_dq_flags[jj] = 1
+            """Then the trimming from the edges passed one another, and this entire order has DQ > 0.  In this case, we include the entire order (for now, we may want to change this in the future though)."""
+            all_wls += list(these_wls)
+            all_fls += list(these_fls)
+            all_flerrs += list(these_flerrs)
+            all_dqs += list(these_dqs)
+    """If every single order had all DQ flags, then we print out the warning."""
+    if sum(all_dq_flags) == n_components:
+        return_title = "Warning: All fluxes have DQ > 0 and != 16."
+    all_wls = numpy.asarray(all_wls)
+    all_fls = numpy.asarray(all_fls)
+    all_flerrs = numpy.asarray(all_flerrs)
+    all_dqs = numpy.asarray(all_dqs)
+    sorted_indexes = numpy.argsort(all_wls)
+    all_wls = all_wls[sorted_indexes]
+    all_fls = all_fls[sorted_indexes]
+    all_flerrs = all_flerrs[sorted_indexes]
+    all_dqs = all_dqs[sorted_indexes]
+    return all_wls, all_fls, all_flerrs, all_dqs, return_title

--- a/specutils_cos.py
+++ b/specutils_cos.py
@@ -1,4 +1,4 @@
-__version__ = '1.05'
+__version__ = '1.1'
 
 """
 .. module:: specutils_cos
@@ -10,26 +10,13 @@ from astropy.io import fits
 import math
 from matplotlib import rc
 import matplotlib.pyplot as pyplot
+from matplotlib.ticker import FormatStrFormatter
 import numpy
 import os
+import specutils
+
 """These are local modules that are imported."""
 from make_hst_spec_previews import HSTSpecPrevError
-
-class COSAvoidRegion:
-    """
-    Defines a COS avoid region, which is simply a section of wavelength space that should not be included when determining the optimal y-axis plot range.  The object consists of a starting wavelength, ending wavelength, and string description of what that region is.
-    :raises: ValueError
-    """
-    def __init__(self, minwl=None, maxwl=None, description=""):
-        if minwl is None:
-            raise ValueError("Must specify a minimum wavelength for this COS avoid region.")
-        if maxwl is None:
-            raise ValueError("Must specify a maximum wavelength for this COS avoid region.")
-        if minwl >= maxwl:
-            raise ValueError("Minimum wavelength must be less than maximum wavelength for this COS avoid region.  Given min. wavelength = "+str(minwl)+" and max. wavelength = "+str(maxwl)+".")
-        self.minwl = minwl
-        self.maxwl = maxwl
-        self.description = description
 
 class COSSpectrum:
     """
@@ -167,12 +154,12 @@ def check_segments(segments_list, input_file):
 
 def generate_cos_avoid_regions():
     """
-    Creates a list of COSAvoidRegion objects for use in the plotting routine, specifically designed for COS spectra.
+    Creates a list of AvoidRegion objects for use in the plotting routine, specifically designed for COS spectra.
     """
-    lya1215_ar = COSAvoidRegion(1214.,1217., "Lyman alpha emission line.")
+    lya1215_ar = specutils.AvoidRegion(1214.,1217., "Lyman alpha emission line.")
     return [lya1215_ar]
 
-def plotspec(cos_spectrum, output_type, output_file, output_size=None):
+def plotspec(cos_spectrum, output_type, output_file, output_size=None, debug=False, full_ylabels=False):
     """
     Accepts a COSSpectrum object from the READSPEC function and produces preview plots.
     :param cos_spectrum: COS spectrum as returned by READSPEC.
@@ -183,6 +170,8 @@ def plotspec(cos_spectrum, output_type, output_file, output_size=None):
     :type output_file: str
     :param output_size: Size of plot in pixels (plots are square in dimensions).  Defaults to 1024.
     :param output_size: int
+    :param full_ylabels: Should the y-labels contain the full values (including the power of 10 in scientific notation)?  Default = False.
+    :type full_ylabels: bool
     :raises: OSError,HSTSpecPrevError
     .. note::
        This function assumes a screen resolution of 96 DPI in order to generate plots of the desired sizes.  This is because matplotlib works in units of inches and DPI rather than pixels.
@@ -225,7 +214,7 @@ def plotspec(cos_spectrum, output_type, output_file, output_size=None):
         subplot_segment_names = ["-".join(segment_names)]
 
     """Start plot figure."""
-    this_figure, these_plotareas = pyplot.subplots(nrows=n_subplots, ncols=1,figsize=(output_size/dpi_val,output_size/dpi_val),dpi=dpi_val)
+    this_figure, these_plotareas = pyplot.subplots(nrows=n_subplots, ncols=1, figsize=(output_size/dpi_val, output_size/dpi_val), dpi=dpi_val)
 
     if not isinstance(these_plotareas, numpy.ndarray):
         these_plotareas = numpy.asarray([these_plotareas])
@@ -240,28 +229,38 @@ def plotspec(cos_spectrum, output_type, output_file, output_size=None):
         if is_bigplot:
             all_wls = cos_spectrum.segments[s].wavelengths
             all_fls = cos_spectrum.segments[s].fluxes
+            all_flerrs = cos_spectrum.segments[s].fluxerrs
             all_dqs = cos_spectrum.segments[s].dqs
+            title_addendum = ""
         else:
-            all_wls, all_fls, all_dqs, title_addendum = stitch_segments(cos_spectrum, segment_names)
+            all_wls, all_fls, all_flerrs, all_dqs, title_addendum = specutils.stitch_components(cos_spectrum, segment_names)
+        if is_bigplot:
+            this_plotarea.set_title(title_addendum, loc="right", size="small", color="red")
+
         """Determine optimal x-axis."""
-        x_axis_range = set_plot_xrange(all_wls, all_fls)
+        median_flux, flux_scale_factor, median_fluxerr, fluxerr_scale_factor, fluxerr_95th, x_axis_range = specutils.set_plot_xrange("cos",all_wls, all_fls, all_flerrs, all_dqs)
         """Plot the spectrum, but only if valid wavelength ranges for x-axis are returned, otherwise plot a special "Fluxes Are All Zero" plot."""
         if all(numpy.isfinite(x_axis_range)):
             """Create COS avoid regions."""
             avoid_regions = generate_cos_avoid_regions()
             """Determine optimal y-axis, but only provide it with fluxes from the part of the spectrum that will be plotted based on the x-axis trimming."""
-            y_axis_range = set_plot_yrange(all_wls, all_fls,avoid_regions=avoid_regions,wl_range=x_axis_range)
-            this_plotarea.plot(all_wls, all_fls, 'k')
-            """Overplot the x-axis edges that are trimmed to define the y-axis plot range as a shaded area."""
-            this_plotarea.axvspan(numpy.nanmin(all_wls), x_axis_range[0],facecolor="lightgrey",alpha=0.5)
-            this_plotarea.axvspan(x_axis_range[1], numpy.nanmax(all_wls),facecolor="lightgrey",alpha=0.5)
-            """Overplot the avoid regions in a light color as a shaded area."""
-            for ar in avoid_regions:
-                this_plotarea.axvspan(ar.minwl,ar.maxwl,facecolor="lightgrey",alpha=0.5)
-            """Update the x-axis and y-axis range, but only adjust the ranges if this isn't an all-zero flux case."""
+            y_axis_range = specutils.set_plot_yrange(all_wls, all_fls, avoid_regions=avoid_regions, wl_range=x_axis_range)
+            this_plotarea.plot(all_wls, all_fls, 'b')
+            this_plotarea.grid(True)
+            """Get the values of the x- and y-axes plot limits that *would* have been used by pyplot automatically."""
+            pyplot_xrange = this_plotarea.get_xlim()
+            pyplot_yrange = this_plotarea.get_ylim()
+            if debug:
+                """Overplot points color-coded based on rejection criteria."""
+                specutils.debug_oplot(this_plotarea, all_wls, all_fls, all_flerrs, all_dqs, median_flux, median_fluxerr, flux_scale_factor, fluxerr_scale_factor, fluxerr_95th)
+                """Overplot the x-axis edges that are trimmed to define the y-axis plot range as a shaded area."""
+                this_plotarea.axvspan(numpy.nanmin(all_wls), x_axis_range[0],facecolor="lightgrey",alpha=0.5)
+                this_plotarea.axvspan(x_axis_range[1], numpy.nanmax(all_wls),facecolor="lightgrey",alpha=0.5)
+                """Overplot the avoid regions in a light color as a shaded area."""
+                for ar in avoid_regions:
+                    this_plotarea.axvspan(ar.minwl,ar.maxwl,facecolor="lightgrey",alpha=0.5)
             """Note that we change the x-axis range here to be the min. and max. wavelength of this segment, rather than using the truncated version, so that all the plots for a similar instrument setting will have the same starting and ending plot values.  But, we still calculate the trimmed starting and ending wavelengths above for other things, such as defining the y-plot range."""
-            x_axis_range = [numpy.nanmin(all_wls),numpy.nanmax(all_wls)]
-            this_plotarea.set_xlim(x_axis_range)
+            this_plotarea.set_xlim(pyplot_xrange)
             """Change x-axis units to microns if a small plot, because there isn't enough space."""
             if not is_bigplot:
                 rc('font', size=10)
@@ -271,24 +270,35 @@ def plotspec(cos_spectrum, output_type, output_file, output_size=None):
             else:
                 """Make sure the font properties go back to normal."""
                 pyplot.rcdefaults()
-                this_plotarea.set_xlabel("Angstroms")
-            this_plotarea.set_ylim(y_axis_range)
+                this_plotarea.set_xlabel(r"Wavelength $(\AA)$")
+                this_plotarea.set_ylabel(r"Flux $\mathrm{(erg/s/cm^2\!/\AA)}$")
+                if full_ylabels:
+                    this_plotarea.yaxis.set_major_formatter(FormatStrFormatter('%3.2E'))
+            """Update y-axis range, but only adjust the ranges if this isn't an all-zero flux case (and not in debug mode, in which case I want to see the entire y-axis range)."""
+            if not debug:
+                this_plotarea.set_ylim(y_axis_range)
         else:
             x_axis_range = [numpy.nanmin(all_wls),numpy.nanmax(all_wls)]
             this_plotarea.set_xlim(x_axis_range)
             this_plotarea.set_axis_bgcolor("lightgrey")
+            this_plotarea.set_yticklabels([])
             if not is_bigplot:
                 rc('font', size=10)
                 this_plotarea.set_xticklabels(this_plotarea.get_xticks()/10000.,rotation=45.)
                 this_plotarea.locator_params(axis="both", nbins=4, steps=[1,2,4,6,8,10])
-                this_figure.suptitle(r'$\lambda in {\mu}m$', position=(0.83,0.99))
+                this_figure.suptitle(r'$\lambda (\mu$m)', position=(0.83,0.99))
                 textsize = "small"
+                plottext = "Fluxes are \n all 0."
             else:
                 """Make sure the font properties go back to normal."""
                 pyplot.rcdefaults()
-                this_plotarea.set_xlabel("Angstroms")
+                this_plotarea.set_xlabel(r"Wavelength $(\AA)$")
+                this_plotarea.set_ylabel(r"Flux $\mathrm{(erg/s/cm^2\!/\AA)}$")
+                if full_ylabels:
+                    this_plotarea.yaxis.set_major_formatter(FormatStrFormatter('%3.2E'))
                 textsize = "x-large"
-            this_plotarea.text(0.5,0.5,"Fluxes are all 0.",horizontalalignment="center",verticalalignment="center",transform=this_plotarea.transAxes,size=textsize)
+                plottext = "Fluxes are all 0."
+            this_plotarea.text(0.5,0.5,plottext,horizontalalignment="center",verticalalignment="center",transform=this_plotarea.transAxes,size=textsize)
 
     """Display or plot to the desired format."""
     if output_type != "screen":
@@ -379,192 +389,3 @@ def readspec(input_file):
         elif band == 'NUV':
             return_spec = COSSpectrum(band=band, cos_segments={'NUVA':nuva_cossegment,'NUVB':nuvb_cossegment,'NUVC':nuvc_cossegment}, orig_file=input_file)
         return return_spec
-
-def _rms(values, offset=0.):
-    """
-    Calculates the RMS about some offset (default offset is 0.)
-    :param values: Array of values to compute the rms of.
-    :type values: numpy.ndarray
-    :param offset: Optional offset to compute the rms about.  Defaults to 0.0.
-    :type offset: float
-    :returns: float -- A scalar float containing the rms about the offset.
-    """
-    return math.sqrt(numpy.nanmean([(x-offset)**2 for x in values]))
-
-def _set_plot_xrange_test(flux_values, median_flux, lt0_fract):
-    """
-    Defines the test for an invalid part of the spectrum when trimming from the edges along the wavelength (x) axis.
-    :param flux_values: An array of fluxes to test.
-    :type flux_values: numpy.ndarray
-    :param median_flux: A median flux value used in the test.
-    :type median_flux: float
-    :param lt0_fract: Fraction of fluxes that are less than zero out of the (good) part of the spectrum (0. <= lt0_fract <= 1.).
-    :type lt0_fract: float
-    :returns: list -- A list of True/False values depening on whether the input flux values pass the test.  Note that if a return value is True, then the flux value is considered PART OF THE SPECTRUM TO TRIM/SKIP OVER.  If median_flux is input as NaN, then this function returns True for all flux_values (i.e., skip all of them since median_flux is not defined).
-    """
-    if not isinstance(flux_values, numpy.ndarray):
-        raise ValueError("The flux values must be passed as a numpy.ndarray object.")
-    if numpy.isfinite(median_flux):
-        if median_flux > 0. and lt0_fract < 0.1:
-            return_var = [x <= 0. or median_flux/x >= 5. for x in flux_values]
-        else:
-            return_var = [x == 0. or median_flux/x >= 5. for x in flux_values]
-    else:
-        return_var = [True] * len(flux_values)
-    return return_var
-    
-def set_plot_xrange(wavelengths,fluxes):
-    """
-    Given an array of wavelengths and fluxes, returns a list of [xmin,xmax] to define an optimal x-axis plot range.
-    :param wavelengths: The wavelengths to be plotted.
-    :type wavelengths: numpy.ndarray
-    :param fluxes: The fluxes to be plotted.
-    :type fluxes: numpy.ndarray
-    :returns: list -- Two-element list containing the optimal [xmin,xmax] values to define the x-axis plot range.
-    """
-    """Test if there are any NaN's in the wavelength array.  If so, issue a warning for now..."""
-    """ NOTE: Use of the SUM here was reported on stackoverflow to be faster than MIN...it won't matter for the sizes we're dealing with here, but I thought it was a neat trick."""
-    if numpy.isnan(numpy.sum(wavelengths)):
-        print "***WARNING in SPECUTILS_COS: Wavelength array contains NaN values.  Behavior has not been fully tested in this case."
-    """Sort the wavelength and flux arrays.  Don't do it in-place since we aren't (yet) going to sort the fluxes, errors, etc. as well."""
-    sorted_indexes = numpy.argsort(wavelengths)
-    sorted_wavelengths = wavelengths[sorted_indexes]
-    sorted_fluxes = fluxes[sorted_indexes]
-    """Find the median flux value, ignoring any NaN values or fluxes that are 0.0."""
-    where_finite_and_notzero = numpy.where( (numpy.isfinite(sorted_fluxes)) & (sorted_fluxes != 0.0) )
-    n_finite_and_notzero = len(where_finite_and_notzero[0])
-    if n_finite_and_notzero > 0:
-        median_flux = numpy.median(sorted_fluxes[where_finite_and_notzero])
-        n_lessthanzero = len(numpy.where(fluxes[where_finite_and_notzero] < 0.)[0])
-        lessthanzero_fract = float(n_lessthanzero) / n_finite_and_notzero
-    else:
-        median_flux = numpy.nan
-        lessthanzero_fract = numpy.nan
-    """Find the first element in the array that is NOT considered an "edge effect", and the last element in the array that is NOT considered an "edge effect".  If the input array is all zeroes, then it will find the last and first element, respectively.  Note that the trim does not just stop at the first index that satisfies this requirement, since there can be spikes at the edges that can fool the algorithm.  Instead, it requires that the next "n_consecutive" data points after each trial location also fail the test for "edge effect"."""
-    n_consecutive = 20
-    start_index = 0
-    end_index = -1
-    n_fluxes = len(sorted_fluxes)
-    done_trimming = False
-    while not done_trimming:
-        if start_index > n_fluxes-n_consecutive-1:
-            done_trimming = True
-        elif not numpy.any(_set_plot_xrange_test(sorted_fluxes[start_index:start_index+n_consecutive+1], median_flux, lessthanzero_fract)):
-            """Test if next "n_consecutive" points also *fail( the edge effect test, e.g., they are from the *good* part of the spectrum, and if so, then we have found a good location and can break out of the while loop."""
-            done_trimming = True
-        else:
-            start_index += 1
-    done_trimming = False
-    while not done_trimming:
-        if end_index < -1*(n_fluxes-n_consecutive):
-            done_trimming = True
-        elif end_index != -1 and not numpy.any(_set_plot_xrange_test(sorted_fluxes[end_index-n_consecutive:end_index+1], median_flux, lessthanzero_fract)):
-            """Test if next "n_consecutive" points also *fail( the edge effect test, e.g., they are from the *good* part of the spectrum, and if so, then we have found a good location and can break out of the while loop."""
-            done_trimming = True
-        elif end_index == -1 and not numpy.any(_set_plot_xrange_test(sorted_fluxes[end_index-n_consecutive:], median_flux, lessthanzero_fract)):
-            """Also test if next "n_consecutive" points also *fail( the edge effect test, e.g., they are from the *good* part of the spectrum, and if so, then we have found a good location and can break out of the while loop.  This extra test is needed due to the vagaries of how python slicing syntax works with negaive indexes.  Probably could just re-write this entirely to use non-negative indexes, but the logic works either way."""
-            done_trimming = True
-        else:
-            end_index -= 1
-    """Return the optimal start and end wavelength values for defining the x-axis plot range.  Note that if the fluxes are all zeroes, then start index will be past end index, so we return NaN values to indicate a special plot should be made in that case.  The odd conditional below checks to make sure the end index (working from the back of the list via negative indexes) stops before reaching the start index (which works from the front using zero-based, positive indexes), otherwise return NaN values because the array is all zeroes."""
-    if n_fluxes + end_index > start_index:
-        return [sorted_wavelengths[start_index],sorted_wavelengths[end_index]]
-    else:
-        return [numpy.nan,numpy.nan]
-
-def set_plot_yrange(wavelengths,fluxes,avoid_regions=None,wl_range=None):
-    """
-    Given an array of wavelengths, fluxes, and avoid regions, returns a list of [ymin,ymax] to define an optimal y-axis plot range.
-    :param wavelengths: The wavelengths to be plotted.
-    :type wavelengths: numpy.ndarray
-    :param fluxes: The fluxes to be plotted.
-    :type fluxes: numpy.ndarray
-    :param avoid_regions: A list of wavelength ranges to avoid when calculating optimal y-axis plot range.
-    :type avoid_regions: list of COSAvoidRegion objects.
-    :param wl_range: The min. and max. wavelength that defines the x-axis plot range.  The default is None, in which case the min. and max. if the input wavelength array will be used.
-    :type wl_range: list
-    :returns: list -- Two-element list containing the optimal [ymin,ymax] values to define the y-axis plot range.
-    .. note::
-       This function makes use of an internal look-up table of wavelength regions where known contaminating emission lines or other strong UV artifacts can affect the zoom level of the plot.
-    """
-    if wl_range is None:
-        wl_range = [numpy.nanmin(wavelengths), numpy.nanmax(wavelengths)]
-    """This list will keep track of which fluxes to retain when defining the y-axis plot range, where setting the value to 1 means keep this flux for consideration."""
-    keep_indices = [1] * len(wavelengths)
-    if avoid_regions is not None:
-        for i,ar in enumerate(avoid_regions):
-            if i == 0:
-                reject_indices = [i for i in range(len(wavelengths)) if wavelengths[i] >= ar.minwl and wavelengths[i] <= ar.maxwl or wavelengths[i] < wl_range[0] or wavelengths[i] > wl_range[1]]
-            else:
-                """Don't need to worry about checking wavelengths within bounds after the first avoid region is examined."""
-                reject_indices = [i for i in range(len(wavelengths)) if wavelengths[i] >= ar.minwl and wavelengths[i] <= ar.maxwl]
-            for j in reject_indices:
-                keep_indices[j] = 0
-    keep_fluxes = numpy.asarray([f for ii,f in enumerate(fluxes) if keep_indices[ii] == 1 and numpy.isfinite(fluxes[ii])])
-    """Don't just take the pure min and max, since weird defects can affect the calculation.  Instead, take the 1th and 99th percentile fluxes within the region to consider."""
-    min_flux = numpy.percentile(keep_fluxes,1.)
-    max_flux = numpy.percentile(keep_fluxes,99.)
-    """Determine a y-buffer based on the difference between the max. and min. flux."""
-    ybuffer = 0.1 * (max_flux-min_flux)
-    return [min_flux-ybuffer, max_flux+ybuffer]
-
-
-def stitch_segments(input_spectrum, segment_names):
-    """
-    Given a COSSpectrum object, stitches each segment into a contiguous array.  Does not do any fitting or adjustments between the orders, but does trim out the edges of each order with flux exactly equal to 0.
-    :param input_spectrum: The COS spectrum to stitch.
-    :type input_spectrum: COSSpectrum
-    :param segment_names: List of segment names.
-    :type segment_names: list
-    :returns: numpy array, numpy array, numpy array, str -- The stitched wavelengths, fluxes, flux errors, and an informational plot title in the event that all the fluxes were exactly equal to 0.
-    """
-    all_wls = []
-    all_fls = []
-    all_dqs = []
-    n_segments = len(segment_names)
-    all_dq_flags = numpy.zeros(n_segments)
-    return_title = ""
-    for j in segment_names:
-        these_wls = input_spectrum.segments[j].wavelengths
-        these_fls = input_spectrum.segments[j].fluxes
-        these_dqs = input_spectrum.segments[j].dqs
-        """Trim from the edges anything with a DQ flag > 0."""
-        start_index = 0
-        while start_index < len(these_dqs):
-            if these_dqs[start_index] == 0:
-                break
-            else:
-                start_index += 1
-        end_index = -1
-        while end_index >= -1*len(these_dqs):
-            if these_dqs[end_index] == 0:
-                break
-            else:
-                end_index -= 1
-        """Only append the parts of this order's spectrum that are not DQ > 0 at the edges."""
-        if len(these_dqs) + end_index > start_index:
-            if end_index == -1:
-                all_wls += list(these_wls[start_index:])
-                all_fls += list(these_fls[start_index:])
-                all_dqs += list(these_dqs[start_index:])
-            else:
-                all_wls += list(these_wls[start_index:end_index+1])
-                all_fls += list(these_fls[start_index:end_index+1])
-                all_dqs += list(these_dqs[start_index:end_index+1])
-        else:
-            all_dq_flags[j] = 1
-            """Then the trimming from the edges passed one another, and this entire order has DQ > 0.  In this case, we include the entire order (for now, we may want to change this in the future though)."""
-            all_wls += list(these_wls)
-            all_fls += list(these_fls)
-            all_dqs += list(these_dqs)
-    """If every single order had all DQ flags, then we print out the warning."""
-    if sum(all_dq_flags) == n_segments:
-        return_title = "Warning: All fluxes have DQ > 0."
-    all_wls = numpy.asarray(all_wls)
-    all_fls = numpy.asarray(all_fls)
-    all_dqs = numpy.asarray(all_dqs)
-    sorted_indexes = numpy.argsort(all_wls)
-    all_wls = all_wls[sorted_indexes]
-    all_fls = all_fls[sorted_indexes]
-    all_dqs = all_dqs[sorted_indexes]
-    return all_wls, all_fls, all_dqs, return_title

--- a/specutils_stis.py
+++ b/specutils_stis.py
@@ -1,4 +1,4 @@
-__version__ = '1.05'
+__version__ = '1.1'
 
 """
 .. module:: specutils_stis
@@ -10,24 +10,10 @@ from astropy.io import fits
 import math
 from matplotlib import rc
 import matplotlib.pyplot as pyplot
+from matplotlib.ticker import FormatStrFormatter
 import numpy
 import os
-
-class STISAvoidRegion:
-    """
-    Defines a STIS avoid region, which is simply a section of wavelength space that should not be included when determining the optimal y-axis plot range.  The object consists of a starting wavelength, ending wavelength, and string description of what that region is.
-    :raises: ValueError
-    """
-    def __init__(self, minwl=None, maxwl=None, description=""):
-        if minwl is None:
-            raise ValueError("Must specify a minimum wavelength for this STIS avoid region.")
-        if maxwl is None:
-            raise ValueError("Must specify a maximum wavelength for this STIS avoid region.")
-        if minwl >= maxwl:
-            raise ValueError("Minimum wavelength must be less than maximum wavelength for this STIS avoid region.  Given min. wavelength = "+str(minwl)+" and max. wavelength = "+str(maxwl)+".")
-        self.minwl = minwl
-        self.maxwl = maxwl
-        self.description = description
+import specutils
 
 class STIS1DSpectrum:
     """
@@ -107,12 +93,12 @@ class STISOrderSpectrum:
 
 def generate_stis_avoid_regions():
     """
-    Creates a list of STISAvoidRegion objects for use in the plotting routine, specifically designed for STIS spectra.
+    Creates a list of AvoidRegion objects for use in the plotting routine, specifically designed for STIS spectra.
     """
-    lya1215_ar = STISAvoidRegion(1214.,1217., "Lyman alpha emission line.")
+    lya1215_ar = specutils.AvoidRegion(1214.,1217., "Lyman alpha emission line.")
     return [lya1215_ar]
 
-def plotspec(stis_spectrum, output_type, output_file, output_size=None):
+def plotspec(stis_spectrum, output_type, output_file, output_size=None, debug=False, full_ylabels=False):
     """
     Accepts a STIS1DSpectrum object from the READSPEC function and produces preview plots.
     :param stis_spectrum: STIS spectrum as returned by READSPEC.
@@ -123,6 +109,8 @@ def plotspec(stis_spectrum, output_type, output_file, output_size=None):
     :type output_file: str
     :param output_size: Size of plot in pixels (plots are square in dimensions).  Defaults to 1024.
     :param output_size: int
+    :param full_ylabels: Should the y-labels contain the full values (including the power of 10 in scientific notation)?  Default = False.
+    :type full_ylabels: bool
     :raises: OSError,HSTSpecPrevError
     .. note::
        This function assumes a screen resolution of 96 DPI in order to generate plots of the desired sizes.  This is because matplotlib works in units of inches and DPI rather than pixels.
@@ -162,7 +150,7 @@ def plotspec(stis_spectrum, output_type, output_file, output_size=None):
         subplot_indexes = [0]
 
     """Start plot figure."""
-    this_figure, these_plotareas = pyplot.subplots(nrows=n_subplots, ncols=1,figsize=(output_size/dpi_val,output_size/dpi_val),dpi=dpi_val)
+    this_figure, these_plotareas = pyplot.subplots(nrows=n_subplots, ncols=1, figsize=(output_size/dpi_val, output_size/dpi_val), dpi=dpi_val)
 
     if not isinstance(these_plotareas, numpy.ndarray):
         these_plotareas = numpy.asarray([these_plotareas])
@@ -174,29 +162,35 @@ def plotspec(stis_spectrum, output_type, output_file, output_size=None):
 
     for c,i in enumerate(subplot_indexes):
         this_plotarea = these_plotareas[c]
-        all_wls, all_fls, all_dqs, title_addendum = stitch_orders(stis_spectrum.associations[i])
+        all_wls, all_fls, all_flerrs, all_dqs, title_addendum = specutils.stitch_components(stis_spectrum.associations[i])
         if is_bigplot:
             this_plotarea.set_title(title_addendum, loc="right", size="small", color="red")
         if n_associations > 1 and is_bigplot:
             this_plotarea.set_title("Association "+str(i+1)+"/"+str(n_associations), loc="center", size="small", color="black")
+
         """Determine optimal x-axis."""
-        x_axis_range = set_plot_xrange(all_wls, all_fls)
+        median_flux, flux_scale_factor, median_fluxerr, fluxerr_scale_factor, fluxerr_95th, x_axis_range = specutils.set_plot_xrange("stis",all_wls, all_fls, all_flerrs, all_dqs)
         if all(numpy.isfinite(x_axis_range)):
             """Create COS avoid regions."""
             avoid_regions = generate_stis_avoid_regions()
             """Determine optimal y-axis, but only provide it with fluxes from the part of the spectrum that will be plotted based on the x-axis trimming."""
-            y_axis_range = set_plot_yrange(all_wls,all_fls,avoid_regions=avoid_regions,wl_range=x_axis_range)
-            this_plotarea.plot(all_wls, all_fls, 'k')
-            """Overplot the x-axis edges that are trimmed to define the y-axis plot range as a shaded area."""
-            this_plotarea.axvspan(numpy.nanmin(all_wls), x_axis_range[0],facecolor="lightgrey",alpha=0.5)
-            this_plotarea.axvspan(x_axis_range[1], numpy.nanmax(all_wls),facecolor="lightgrey",alpha=0.5)
-            """Overplot the avoid regions in a light color as a shaded area."""
-            for ar in avoid_regions:
-                this_plotarea.axvspan(ar.minwl,ar.maxwl,facecolor="lightgrey",alpha=0.5)
-            """Update the x-axis and y-axis range, but only adjust the ranges if this isn't an all-zero flux case."""
+            y_axis_range = specutils.set_plot_yrange(all_wls, all_fls, avoid_regions=avoid_regions, wl_range=x_axis_range)
+            this_plotarea.plot(all_wls, all_fls, 'b')
+            this_plotarea.grid(True)
+            """Get the values of the x- and y-axes plot limits that *would* have been used by pyplot automatically."""
+            pyplot_xrange = this_plotarea.get_xlim()
+            pyplot_yrange = this_plotarea.get_ylim()
+            if debug:
+                """Overplot points color-coded based on rejection criteria."""
+                specutils.debug_oplot(this_plotarea, all_wls, all_fls, all_flerrs, all_dqs, median_flux, median_fluxerr, flux_scale_factor, fluxerr_scale_factor, fluxerr_95th)
+                """Overplot the x-axis edges that are trimmed to define the y-axis plot range as a shaded area."""
+                this_plotarea.axvspan(numpy.nanmin(all_wls), x_axis_range[0],facecolor="lightgrey",alpha=0.5)
+                this_plotarea.axvspan(x_axis_range[1], numpy.nanmax(all_wls),facecolor="lightgrey",alpha=0.5)
+                """Overplot the avoid regions in a light color as a shaded area."""
+                for ar in avoid_regions:
+                    this_plotarea.axvspan(ar.minwl,ar.maxwl,facecolor="lightgrey",alpha=0.5)
             """Note that we change the x-axis range here to be the min. and max. wavelength of this segment, rather than using the truncated version, so that all the plots for a similar instrument setting will have the same starting and ending plot values.  But, we still calculate the trimmed starting and ending wavelengths above for other things, such as defining the y-plot range."""
-            x_axis_range = [numpy.nanmin(all_wls),numpy.nanmax(all_wls)]
-            this_plotarea.set_xlim(x_axis_range)
+            this_plotarea.set_xlim(pyplot_xrange)
             """Change x-axis units to microns if a small plot, because there isn't enough space."""
             if not is_bigplot:
                 rc('font', size=10)
@@ -206,24 +200,35 @@ def plotspec(stis_spectrum, output_type, output_file, output_size=None):
             else:
                 """Make sure the font properties go back to normal."""
                 pyplot.rcdefaults()
-                this_plotarea.set_xlabel("Angstroms")
-            this_plotarea.set_ylim(y_axis_range)
+                this_plotarea.set_xlabel(r"Wavelength $(\AA)$")
+                this_plotarea.set_ylabel(r"Flux $\mathrm{(erg/s/cm^2\!/\AA)}$")
+                if full_ylabels:
+                    this_plotarea.yaxis.set_major_formatter(FormatStrFormatter('%3.2E'))
+            """Update y-axis range, but only adjust the ranges if this isn't an all-zero flux case (and not in debug mode, in which case I want to see the entire y-axis range)."""
+            if not debug:
+                this_plotarea.set_ylim(y_axis_range)
         else:
             x_axis_range = [numpy.nanmin(all_wls),numpy.nanmax(all_wls)]
             this_plotarea.set_xlim(x_axis_range)
             this_plotarea.set_axis_bgcolor("lightgrey")
+            this_plotarea.set_yticklabels([])
             if not is_bigplot:
                 rc('font', size=10)
                 this_plotarea.set_xticklabels(this_plotarea.get_xticks()/10000.,rotation=45.)
                 this_plotarea.locator_params(axis="both", nbins=4, steps=[1,2,4,6,8,10])
-                this_figure.suptitle(r'$\lambda in {\mu}m$', position=(0.83,0.99))
+                this_figure.suptitle(r'$\lambda (\mu$m)', position=(0.83,0.99))
                 textsize = "small"
+                plottext = "Fluxes are \n all 0."
             else:
                 """Make sure the font properties go back to normal."""
                 pyplot.rcdefaults()
-                this_plotarea.set_xlabel("Angstroms")
+                this_plotarea.set_xlabel(r"Wavelength $(\AA)$")
+                this_plotarea.set_ylabel(r"Flux $\mathrm{(erg/s/cm^2\!/\AA)}$")
+                if full_ylabels:
+                    this_plotarea.yaxis.set_major_formatter(FormatStrFormatter('%3.2E'))
                 textsize = "x-large"
-            this_plotarea.text(0.5,0.5,"Fluxes are all 0.",horizontalalignment="center",verticalalignment="center",transform=this_plotarea.transAxes,size=textsize)
+                plottext = "Fluxes are all 0."
+            this_plotarea.text(0.5,0.5,plottext,horizontalalignment="center",verticalalignment="center",transform=this_plotarea.transAxes,size=textsize)
 
     """Display or plot to the desired format."""
     if output_type != "screen":
@@ -257,166 +262,3 @@ def readspec(input_file):
             this_exposure_spectrum = STISExposureSpectrum(order_spectra=all_order_spectra)
             all_association_spectra.append(this_exposure_spectrum)
         return STIS1DSpectrum(association_spectra=all_association_spectra, orig_file=input_file)
-
-def _set_plot_xrange_test(flux_values, median_flux):
-    """
-    Defines the test for an invalid part of the spectrum when trimming from the edges along the wavelength (x) axis.
-    :param flux_values: A scalar float or list of fluxes to test.
-    :type flux_values: float or list
-    :param median_flux: A median flux value used in the test.
-    :type median_flux: float
-    :returns: float or list -- A scalar float or list of True/False values depening on whether the input flux values pass the test.  Return type matches the type of the input flux values.  Note that if a return value is True, then the flux value is considered PART OF THE SPECTRUM TO TRIM/SKIP OVER.  If median_flux is input as NaN, then this function returns True for all flux_values (i.e., skip all of them since median_flux is not defined).
-    """
-    if isinstance(flux_values, numpy.ndarray):
-        if numpy.isfinite(median_flux):
-            return_var = [x == 0. or median_flux/x >= 5. for x in flux_values]
-        else:
-            return_var = [True] * len(flux_values)
-    else:
-        return_var = flux_values == 0. or median_flux/flux_values >= 5. or numpy.isfinite(median_flux)
-    return return_var
-    
-def set_plot_xrange(wavelengths,fluxes):
-    """
-    Given an array of wavelengths and fluxes, returns a list of [xmin,xmax] to define an optimal x-axis plot range.
-    :param wavelengths: The wavelengths to be plotted.
-    :type wavelengths: numpy.ndarray
-    :param fluxes: The fluxes to be plotted.
-    :type fluxes: numpy.ndarray
-    :returns: list -- Two-element list containing the optimal [xmin,xmax] values to define the x-axis plot range.
-    """
-    """Test if there are any NaN's in the wavelength array.  If so, issue a warning for now..."""
-    """ NOTE: Use of the SUM here was reported on stackoverflow to be faster than MIN...it won't matter for the sizes we're dealing with here, but I thought it was a neat trick."""
-    if numpy.isnan(numpy.sum(wavelengths)):
-        print "***WARNING in SPECUTILS_STIS: Wavelength array contains NaN values.  Behavior has not been fully tested in this case."
-    """Find the median flux value, ignoring any NaN values or fluxes that are 0.0."""
-    where_finite_and_notzero = numpy.where( (numpy.isfinite(fluxes)) & (fluxes != 0.0) )
-    if len(where_finite_and_notzero[0]) > 0:
-        median_flux = numpy.median(fluxes[where_finite_and_notzero])
-    else:
-        median_flux = numpy.nan
-    """Find the first element in the array that is NOT considered an "edge effect", and the last element in the array that is NOT considered an "edge effect".  If the input array is all zeroes, then it will find the last and first element, respectively.  Note that the trim does not just stop at the first index that satisfies this requirement, since there can be spikes at the edges that can fool the algorithm.  Instead, it requires that the next "n_consecutive" data points after each trial location also fail the test for "edge effect"."""
-    n_consecutive = 20
-    start_index = 0
-    end_index = -1
-    n_fluxes = len(fluxes)
-    done_trimming = False
-    while not done_trimming:
-        if start_index > n_fluxes-n_consecutive-1:
-            done_trimming = True
-        elif not numpy.any(_set_plot_xrange_test(fluxes[start_index:start_index+n_consecutive+1], median_flux)):
-            """Test if next "n_consecutive" points also *fail( the edge effect test, e.g., they are from the *good* part of the spectrum, and if so, then we have found a good location and can break out of the while loop."""
-            done_trimming = True
-        else:
-            start_index += 1
-    done_trimming = False
-    while not done_trimming:
-        if end_index < -1*(n_fluxes-n_consecutive):
-            done_trimming = True
-        elif end_index != -1 and not numpy.any(_set_plot_xrange_test(fluxes[end_index-n_consecutive:end_index+1], median_flux)):
-            """Test if next "n_consecutive" points also *fail( the edge effect test, e.g., they are from the *good* part of the spectrum, and if so, then we have found a good location and can break out of the while loop."""
-            done_trimming = True
-        elif end_index == -1 and not numpy.any(_set_plot_xrange_test(fluxes[end_index-n_consecutive:], median_flux)):
-            """Also test if next "n_consecutive" points also *fail( the edge effect test, e.g., they are from the *good* part of the spectrum, and if so, then we have found a good location and can break out of the while loop.  This extra test is needed due to the vagaries of how python slicing syntax works with negaive indexes.  Probably could just re-write this entirely to use non-negative indexes, but the logic works either way."""
-            done_trimming = True
-        else:
-            end_index -= 1
-    """Return the optimal start and end wavelength values for defining the x-axis plot range.  Note that if the fluxes are all zeroes, then start index will be past end index, so we return NaN values to indicate a special plot should be made in that case.  The odd conditional below checks to make sure the end index (working from the back of the list via negative indexes) stops before reaching the start index (which works from the front using zero-based, positive indexes), otherwise return NaN values because the array is all zeroes."""
-    if n_fluxes + end_index > start_index:
-        return [wavelengths[start_index],wavelengths[end_index]]
-    else:
-        return [numpy.nan,numpy.nan]
-
-def set_plot_yrange(wavelengths,fluxes,avoid_regions=None,wl_range=None):
-    """
-    Given an array of wavelengths, fluxes, and avoid regions, returns a list of [ymin,ymax] to define an optimal y-axis plot range.
-    :param wavelengths: The wavelengths to be plotted.
-    :type wavelengths: numpy.ndarray
-    :param fluxes: The fluxes to be plotted.
-    :type fluxes: numpy.ndarray
-    :param avoid_regions: A list of wavelength ranges to avoid when calculating optimal y-axis plot range.
-    :type avoid_regions: list of STISAvoidRegion objects.
-    :param wl_range: The min. and max. wavelength that defines the x-axis plot range.  The default is None, in which case the min. and max. if the input wavelength array will be used.
-    :type wl_range: list
-    :returns: list -- Two-element list containing the optimal [ymin,ymax] values to define the y-axis plot range.
-    .. note::
-       This function makes use of an internal look-up table of wavelength regions where known contaminating emission lines or other strong UV artifacts can affect the zoom level of the plot.
-    """
-    if wl_range is None:
-        wl_range = [numpy.nanmin(wavelengths), numpy.nanmax(wavelengths)]
-    """This list will keep track of which fluxes to retain when defining the y-axis plot range, where setting the value to 1 means keep this flux for consideration."""
-    keep_indices = [1] * len(wavelengths)
-    if avoid_regions is not None:
-        for i,ar in enumerate(avoid_regions):
-            if i == 0:
-                reject_indices = [i for i in range(len(wavelengths)) if wavelengths[i] >= ar.minwl and wavelengths[i] <= ar.maxwl or wavelengths[i] < wl_range[0] or wavelengths[i] > wl_range[1]]
-            else:
-                """Don't need to worry about checking wavelengths within bounds after the first avoid region is examined."""
-                reject_indices = [i for i in range(len(wavelengths)) if wavelengths[i] >= ar.minwl and wavelengths[i] <= ar.maxwl]
-            for j in reject_indices:
-                keep_indices[j] = 0
-    keep_fluxes = numpy.asarray([f for ii,f in enumerate(fluxes) if keep_indices[ii] == 1 and numpy.isfinite(fluxes[ii])])
-    """Don't just take the pure min and max, since weird defects can affect the calculation.  Instead, take the 1th and 99th percentile fluxes within the region to consider."""
-    min_flux = numpy.percentile(keep_fluxes,1.)
-    max_flux = numpy.percentile(keep_fluxes,99.)
-    """Determine a y-buffer based on the difference between the max. and min. flux."""
-    ybuffer = 0.1 * (max_flux-min_flux)
-    return [min_flux-ybuffer, max_flux+ybuffer]
-
-def stitch_orders(input_exposure):
-    """
-    Given a STISExposureSpectrum object, stitches each order into a contiguous array.  Does not do any fitting or adjustments between the orders, but does trim out the edges of each order with DQ flags > 0.
-    :param input_exposure: The STIS exposure spectrum to stitch.
-    :type input_exposure: STISExposureSpectrum
-    :returns: numpy array, numpy array, numpy array, str -- The stitched wavelengths, fluxes, flux errors, and an informational plot title in the event that all the fluxes had the DQ flag set.
-    """
-    all_wls = []
-    all_fls = []
-    all_dqs = []
-    n_orders = len(input_exposure.orders)
-    all_dq_flags = numpy.zeros(n_orders)
-    return_title = ""
-    for j in xrange(n_orders):
-        these_wls = input_exposure.orders[j].wavelengths
-        these_fls = input_exposure.orders[j].fluxes
-        these_dqs = input_exposure.orders[j].dqs
-        """Trim from the edges anything with a DQ flag > 0."""
-        start_index = 0
-        while start_index < len(these_dqs):
-            if these_dqs[start_index] == 0:
-                break
-            else:
-                start_index += 1
-        end_index = -1
-        while end_index >= -1*len(these_dqs):
-            if these_dqs[end_index] == 0:
-                break
-            else:
-                end_index -= 1
-        """Only append the parts of this order's spectrum that are not DQ > 0 at the edges."""
-        if len(these_dqs) + end_index > start_index:
-            if end_index == -1:
-                all_wls += list(these_wls[start_index:])
-                all_fls += list(these_fls[start_index:])
-                all_dqs += list(these_dqs[start_index:])
-            else:
-                all_wls += list(these_wls[start_index:end_index+1])
-                all_fls += list(these_fls[start_index:end_index+1])
-                all_dqs += list(these_dqs[start_index:end_index+1])
-        else:
-            all_dq_flags[j] = 1
-            """Then the trimming from the edges passed one another, and this entire order has DQ > 0.  In this case, we include the entire order (for now, we may want to change this in the future though)."""
-            all_wls += list(these_wls)
-            all_fls += list(these_fls)
-            all_dqs += list(these_dqs)
-    """If every single order had all DQ flags, then we print out the warning."""
-    if sum(all_dq_flags) == n_orders:
-        return_title = "Warning: All fluxes have DQ > 0."
-    all_wls = numpy.asarray(all_wls)
-    all_fls = numpy.asarray(all_fls)
-    all_dqs = numpy.asarray(all_dqs)
-    sorted_indexes = numpy.argsort(all_wls)
-    all_wls = all_wls[sorted_indexes]
-    all_fls = all_fls[sorted_indexes]
-    all_dqs = all_dqs[sorted_indexes]
-    return all_wls, all_fls, all_dqs, return_title


### PR DESCRIPTION
- Test used for trim edges can be adjusted using boolean flags to turn on/off various aspects of the test.
- DQ flags now used to trim edges when determining y-axis range.
- Ratio of flux uncertainties used to trim edges.
- PNG plots are now consistent sizes.
- y-tick labels are now turned off in cases of fluxes being all 0.0.
- Spectral plots are now blue instead of black (except in debug mode).
- Both x- and y-axes now have unit labels.
- Grid lines are now included in large size plots.
- Added option (defaults to False) that uses full value labels for y-axis major tickmarks (includes powers of 10 in scientific notation).
- Added optional test to edge trimming that checks percentiles of flux uncertainties.
- Moved a lot of the common methods into a separate module called specutils.py that reduces code duplication.
- DQ test of edge trimming now avoids DQ=16 flags for STIS, but not for COS.
- There are additional fixes and improvements with this update that are not directly associated with an Issue.
