### PR TITLE
Switch to tostring_argb

### DIFF
--- a/History.rst
+++ b/History.rst
@@ -1,11 +1,19 @@
 Change Log for SPEC_PLOTS
 =========================
 
-v1.36.1 - 2025 Feb. 14
+v1.37.0 - 2025 TBD  
 ----------------------
-* Fixed incorrect units being shown for JWST NIRSPEC 1D files
-* NIRCam x1d files now supported
- 
+* Switched to using `tostring_argb()` in `calc_covering_fraction`
+  for compatibility with matplotlib > 3.10.0
+* Removed a misleading comment in readspec to reflect that JWST are
+  not always stored in the first extension, nor do they need to be for
+  `spec_plots` to work.
+  
+v1.36.1 - 2025 Feb. 14  
+----------------------
+* Fixed incorrect units being shown for JWST NIRSPEC 1D files  
+* NIRCam x1d files now supported  
+  
 v1.36.0 - 2024 Feb. 9  
 -----------------
 * Added basic support HST Hubble Advanced Spectral Products (HASP)  

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(name="spec_plots",
                 "spec_plots.utils.specutils_hasp",
                 "spec_plots.utils.specutils_jwst",
                 "spec_plots.utils.specutils_stis"],
-      install_requires=["astropy>=5.2.2", "matplotlib>=3.7.1", "numpy>=1.24.3",
+      install_requires=["astropy>=5.3.3", "matplotlib>=3.7.1", "numpy>=1.24.3",
                         "future>=0.18.3"],
       entry_points={"console_scripts" :
                     ["make_hst_spec_previews = spec_plots.__main__:main",

--- a/spec_plots/__init__.py
+++ b/spec_plots/__init__.py
@@ -8,4 +8,4 @@
 
 from __future__ import absolute_import
 
-__version__ = '1.36.1'
+__version__ = '1.37.0'

--- a/spec_plots/utils/specutils/calc_covering_fraction.py
+++ b/spec_plots/utils/specutils/calc_covering_fraction.py
@@ -99,7 +99,10 @@ def calc_covering_fraction(fig, subplots, subplot_num, optimize=True):
 
     # Draw the plot, convert into numpy array of RGB values.
     fig.canvas.draw()
-    buf = numpy.fromstring(fig.canvas.tostring_rgb(), dtype=numpy.uint8)
+    buf = numpy.fromstring(fig.canvas.tostring_argb(), dtype=numpy.uint8)
+    # tostring_argb gives {alpha, r, g, b}, so reform with a mask skipping over
+    # alpha values.
+    buf = buf[numpy.arange(buf.shape[0]) % 4 != 0]
 
     # Count the number of "blue" and "red" pixels.  The optimized version
     # attempts to split the RGB array into equal slices so that the counting of

--- a/spec_plots/utils/specutils_jwst/readspec.py
+++ b/spec_plots/utils/specutils_jwst/readspec.py
@@ -41,9 +41,7 @@ def readspec(input_file):
     """
 
     with fits.open(input_file) as hdulist:
-
-        # Read the data from the first extension.  For JWST, the spectra are
-        # always stored as tables in the first FITS extension.
+        # Read the data from the "EXTRACT1D" FITS extension.
         try:
             jwst_table = Table.read(hdulist["EXTRACT1D"],
                                         unit_parse_strict='silent')


### PR DESCRIPTION
This PR addresses Issue #115 , where matplotlib's tostring_rgb() needed to be replaced with tostring_argb().  This requred one extra line to change the array the code worked with that previously contained a series of r,g,b values per pixel to skip over the alpha values returned, since tostring_argb() returns 4-tuples of a,r,g,b.

No particularly urgency on the review.  Ensure regression samples still produce good output using this branch prior to merge.