### PR TITLE
Update for HASP target-level products

### DIFF
--- a/spec_plots/make_hst_spec_previews.py
+++ b/spec_plots/make_hst_spec_previews.py
@@ -138,10 +138,10 @@ def is_hasp_product(input_file):
 
     :type input_file: str
 
-    :returns: bool -- Returns True if the filename ends in _cspec.fits.
+    :returns: bool -- Returns True if the filename ends in _aspec.fits or _cspec.fits.
     """
 
-    if input_file.endswith("_cspec.fits"):
+    if input_file.endswith("_cspec.fits") or input_file.endswith("_aspec.fits"):
         return True
     return False
 


### PR DESCRIPTION
Update needed to handle new products generated by the HASP code for target-level products, which introduce abutted spectra that have file names ending in _aspec.fits.