### PR TITLE
updating fromstring to frombuffer

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
     - main
-    - switch_to_tostring_agrb
-    - add_ghactions
     tags:
   pull_request:
     branches:

--- a/History.rst
+++ b/History.rst
@@ -1,20 +1,24 @@
 Change Log for SPEC_PLOTS
 =========================
 
-v1.37.0 - 2025 TBD  
+v1.37.0 - 2025 June 17 
 ----------------------
 * Switched to using `tostring_argb()` in `calc_covering_fraction`
   for compatibility with matplotlib > 3.10.0
 * Removed a misleading comment in readspec to reflect that JWST are
   not always stored in the first extension, nor do they need to be for
   `spec_plots` to work.
+* All error states end with a sys.error(1) error code now.
+* Updated numpy.fromstring() to use numpy.frombuffer() for
+  compatibility with numpy > v2.2.0
   
-v1.36.1 - 2025 Feb. 14  
+  
+v1.36.1 - 2025 Feb. 14 
 ----------------------
 * Fixed incorrect units being shown for JWST NIRSPEC 1D files  
 * NIRCam x1d files now supported  
   
-v1.36.0 - 2024 Feb. 9  
+v1.36.0 - 2024 Feb. 9 
 -----------------
 * Added basic support HST Hubble Advanced Spectral Products (HASP)  
  

--- a/docs/README_DEVELOPERS.txt
+++ b/docs/README_DEVELOPERS.txt
@@ -1,28 +1,24 @@
 Best Practices for Development Of A New Branch
 
-1.)  Crate a new branch with the name v<x.yy>, for example, if beginning work on branch 1.45.0, name the branch 'v1.45.0'.
+1.)  When making a change create a branch off main branch.  Release of new packages is done off main branch when ready to do so.
 
-2.)  You will need to update the README.md file inside the "spec_plots" folder to point to the new branch if you want the READTHEDOCS icons to be up-to-date.  You will also need to make sure the new branch is set to "active" at readthedocs.org after the first push to the new branch, so that it will auto-build after each git commit moving forwards.
+2.)  You will need to make sure the new branch is set to "active" at readthedocs.org after the first push to the new branch, so you can trigger builds manually.  If you want to enable CI on your development branch, edit the ci_workflows.yml file in the .github folder to include the name of the branch under "push".
 
 3.)  Update the version number in the __init__.py under spect_plots/.  This version is imported by all other modules, so it defines the version of the software throughout the repo.
 
 4.)  When doing git commits, refer to github Issue numbers when they are fixed in the commit notes so that github will assign this commit to that Issue, e.g., "- Fixes #44".
 
-5.)  Upate the History.rst file in the main directory with a summary of the changes, used by PyPI to track changes between versions.
+5.)  Before releasing a version from main branch, update the History.rst file in the main directory with a summary of the changes.
 
 6.)  Re-build the EGG and WHEEL distributions using the "build_package.sh" script at the top level.
 
 7.)  Keep the various documentation files (mostly located inside the "docs" folder) as up-to-date as possible before final commit to the branch.
 
-8.)  After doing a final commit of the branch, make sure all Github Issues are closed for that branch, or re-assigned if punting to a later build for that Issue.
+8.)  To upload to PyPI with twine: twine upload dist/*, with the -u and -p options.
 
-9.)  After regression testing is finished and all Issues assigned to this branch are closed or moved to a future build, initiate a pull request and merge into main.
+9.)  After uploading to PyPI, you can build the conda package.  Inside the "conda" folder in the top-level directory, run "conda skeleton pypi spec-plots" (if you want to remake the "meta.yaml" file from scratch, but first make sure you save a copy of the "conda_build_config.yaml"), then "conda build spec-plots".  NOTE: lately the "conda skeleton" command hasn't run successfully, so lately the process has been to edit the "meta.yaml" file directly, including the URL and checksum hash for the PyPI version you are building.
 
-10.)  To upload to PyPI with twine: twine upload dist/*, with the -u and -p options.
+12.)  Now you can convert the build file to other platforms.  E.g., "conda convert -f --platform linux-64 <name of .tar.bz2>".  Note that you'll need to locate where the conda build package was output and run it there.  The output of the original build is reported when run when you first create it. Lately, only the osx-arm64 platform is being built.
 
-11.)  After uploading to PyPI, you can build the conda package.  Inside the "conda" folder in the top-level directory, run "conda skeleton pypi spec-plots" (if you want to remake the "meta.yaml" file from scratch, but first make sure you save a copy of the "conda_build_config.yaml"), then "conda build spec-plots".  NOTE: lately the "conda skeleton" command hasn't run successfully, so lately the process has been to edit the "meta.yaml" file directly, including the URL and checksum hash for the PyPI version you are building.
-
-12.)  Now you can convert the build file to other platforms.  E.g., "conda convert -f --platform linux-64 <name of .tar.bz2>".  Note that you'll need to locate where the conda build package was output and run it there.  The output of the original build is reported when run when you first create it. Lately only the osx-arm64 platform is being built.
-
-13.)  Test the build using "conda install --use-local spec-plots".  If everything looks good, upload it to anaconda.org using "anaconda upload /Users/fleming/anaconda2/conda-bld/osx-64/spec-plots-1.34.2-py27_0.tar.bz2", where the last part is the name of the built .tar.bz2 file.
+13.)  Test the build using "conda install --use-local spec-plots".  If everything looks good, upload it to anaconda.org using, e.g., "anaconda upload <conda_dir>/anaconda3/conda-bld/osx-64/spec-plots-1.34.2-py27_0.tar.bz2", where the last part is the name of the built .tar.bz2 file.
 

--- a/spec_plots/utils/specutils/calc_covering_fraction.py
+++ b/spec_plots/utils/specutils/calc_covering_fraction.py
@@ -99,7 +99,7 @@ def calc_covering_fraction(fig, subplots, subplot_num, optimize=True):
 
     # Draw the plot, convert into numpy array of RGB values.
     fig.canvas.draw()
-    buf = numpy.fromstring(fig.canvas.tostring_argb(), dtype=numpy.uint8)
+    buf = numpy.frombuffer(fig.canvas.tostring_argb(), dtype=numpy.uint8)
     # tostring_argb gives {alpha, r, g, b}, so reform with a mask skipping over
     # alpha values.
     buf = buf[numpy.arange(buf.shape[0]) % 4 != 0]


### PR DESCRIPTION
Updating `numpy.fromstring()` to  `numpy.frombuffer()` to stay compatible with numpy == 2.3

I confirmed that the output from `numpy.fromstring()` and `numpy.frombuffer()` are identical in both numpy versions 1.24.1 and 2.2 for backwards compatibility.